### PR TITLE
Add venv folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 github.code-workspace
 task-library/fortigate/FortiOS 6.0.6 REST API Reference.pdf
 .vscode/settings.json
+venv/


### PR DESCRIPTION
Preparation for recommended use of **venv** when running these Python scripts.  "venv/" folder should be excluded from source control via repo .gitignore.